### PR TITLE
NestStack and AutoStartup of the CB and Glue Jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__
 bandit*.out
 cdk.out
 cdk.context.json
+env
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@ __pycache__
 bandit*.out
 cdk.out
 cdk.context.json
-env
-.env

--- a/README.md
+++ b/README.md
@@ -2,19 +2,25 @@
 
 ## Table of Content
 
-1. [Overview](#overview)
+- [Deploing Privacy Sandbox on AWS](#deploing-privacy-sandbox-on-aws)
+  - [Table of Content](#table-of-content)
+  - [Overview](#overview)
+    - [Architecture Overview](#architecture-overview)
     - [Cost](#cost)
-2. [Prerequisites](#prerequisites)
+  - [Prerequisites](#prerequisites)
     - [Operating System](#operating-system)
-3. [Deployment Steps](#deployment-steps)
-4. [Deployment Validation](#deployment-validation)
-5. [Running the Guidance](#running-the-guidance)
-6. [Next Steps](#next-steps)
-7. [Cleanup](#cleanup)
-8. [FAQ, known issues, additional considerations, and limitations](#faq-known-issues-additional-considerations-and-limitations)
-9. [Revisions](#revisions)
-10. [Notices](#notices)
-11. [Authors](#authors)
+    - [Python Dependencies](#python-dependencies)
+    - [AWS CDK bootstrap](#aws-cdk-bootstrap)
+  - [Deployment Steps](#deployment-steps)
+  - [Deployment Validation](#deployment-validation)
+  - [Running the Guidance](#running-the-guidance)
+    - [Expected output](#expected-output)
+  - [Next Steps](#next-steps)
+  - [Cleanup](#cleanup)
+  - [FAQ, known issues, additional considerations, and limitations](#faq-known-issues-additional-considerations-and-limitations)
+  - [Revisions](#revisions)
+  - [Notices](#notices)
+  - [Authors](#authors)
 
 ## Overview
 This solution demonstrates how to deploy the Privacy Sandbox Private Aggregation Service and supporting services for Privacy Sandbox report collection and processing on AWS. The guidance currently does not implement batching functionality required to process reports, but will be updated in the future to support this.
@@ -26,7 +32,6 @@ This solution demonstrates how to deploy the Privacy Sandbox Private Aggregation
 ### Cost
 
 _You are responsible for the cost of the AWS services used while running this Guidance. As of May 2024, the cost for running this Guidance with the default settings in the <Default AWS Region (Most likely will be US East (N. Virginia)) > is approximately $2,599 per month for processing ( 30 million records each day )._
-
 
 
 ## Prerequisites
@@ -72,7 +77,7 @@ cdk bootstrap --profile <profile name>
 
 1. Clone this repository to your development desktop
 ```
-git clone **TODO GITHUB URL**
+git clone https://github.com/aws-solutions-library-samples/guidance-for-implementing-the-google-privacy-sandbox-aggregation-service-on-aws.git
 ```
 2. Use [envsetup.sh](./envsetup.sh) to setup virtual environment and install python dependencies
 
@@ -88,16 +93,7 @@ git clone **TODO GITHUB URL**
 
  ```
 
-5. Deploy the [CollectorBuild]('./deployment/collector_build.py') stack.
-```
-    cdk deploy CollectorBuild --profile <profile name>
-```
-
-6. Navigate to AWS CodeBuild in the console and locate the project created by the previous step. Start the build. Once the build has completed successfully proceed to the next step.
-
-7.  cdk deploy CollectorService --profile <profile name>
-
-8. Navigate to Glue ETL Jobs in the AWS Console and run the following Glue Jobs: job-aggregate-raw, job-aggregate-avro
+5.  cdk deploy --all --profile <profile name>
 
 
 ## Deployment Validation

--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 import aws_cdk as cdk
-from aws_cdk import Tags
+from aws_cdk import Tags, Stack
 
 from deployment.collector_build import CollectorBuild
 from deployment.collector_service import CollectorServiceStack
@@ -11,29 +11,34 @@ from deployment.glue import GlueStack
 from cdk_nag import AwsSolutionsChecks, NagSuppressions
 
 app = cdk.App()
+
+# Create main stack
+main_stack = Stack(app, 'AggregationServiceStack')
+
+
 project_name = app.node.try_get_context("project_name")
 guidance_description = "Guidance for deploying Privacy Sandbox Private Aggregation API on AWS (SO9455)"
-collector_build = CollectorBuild(app, "CollectorBuild", description="guidance_description")
+collector_build = CollectorBuild(main_stack, "CollectorBuild", description="guidance_description")
 Tags.of(collector_build).add("project", project_name)
 
-kms_key_stack = KMSKeyStack(app, "KMSKeyStack", description="guidance_description")
+kms_key_stack = KMSKeyStack(main_stack, "KMSKeyStack", description="guidance_description")
 Tags.of(kms_key_stack).add("project", project_name)
 
-s3_collector_destination = S3Stack(app, 'CollectedDataS3Stack', description="guidance_description")
+s3_collector_destination = S3Stack(main_stack, 'CollectedDataS3Stack', description="guidance_description")
 Tags.of(s3_collector_destination).add("project", project_name)
 
-s3_summary_destination = S3Stack(app, 'AggregationSummaryDataS3Stack', description="guidance_description")
+s3_summary_destination = S3Stack(main_stack, 'AggregationSummaryDataS3Stack', description="guidance_description")
 Tags.of(s3_summary_destination).add("project", project_name)
 
-kds_stack_aggregatable_report = KinesisDataStreamsStack(app, 'AggregatableGPSAggServiceCollectorKinesisDataStreamsStack',kms_key=kms_key_stack.kms_key,api_name="gps_aggregatable_report", description="guidance_description")
+kds_stack_aggregatable_report = KinesisDataStreamsStack(main_stack, 'AggregatableGPSAggServiceCollectorKinesisDataStreamsStack',kms_key=kms_key_stack.kms_key,api_name="gps_aggregatable_report", description="guidance_description")
 Tags.of(kds_stack_aggregatable_report).add("project", project_name)
 
-glue_aggregatable_report = GlueStack(app, "GlueToS3Stack",kms_key=kms_key_stack.kms_key,api_name="gps_aggregatable_report",
+glue_aggregatable_report = GlueStack(main_stack, "GlueToS3Stack",kms_key=kms_key_stack.kms_key,api_name="gps_aggregatable_report",
   source_kinesis_stream=kds_stack_aggregatable_report.kinesis_stream,s3_collector_destination=s3_collector_destination.s3_bucket
 , description="guidance_description")
 Tags.of(glue_aggregatable_report).add("project", project_name)
 
-collector_service = CollectorServiceStack(app, "CollectorService", source_kinesis_stream=kds_stack_aggregatable_report.kinesis_stream.stream_name, kms_key=kms_key_stack.kms_key.key_id, description="guidance_description")
+collector_service = CollectorServiceStack(main_stack, "CollectorService", source_kinesis_stream=kds_stack_aggregatable_report.kinesis_stream.stream_name, kms_key=kms_key_stack.kms_key.key_id, description="guidance_description")
 collector_service.add_dependency(kms_key_stack)
 collector_service.add_dependency(glue_aggregatable_report)
 collector_service.add_dependency(kds_stack_aggregatable_report)

--- a/cdk.context.json.example
+++ b/cdk.context.json.example
@@ -18,6 +18,8 @@
     "glue_table_agg_raw": "aggregation_report_raw",
     "glue_table_agg_avro": "aggregation_report_avro",
 
+    "auto_start_glue_jobs": true,
+
     "collector_ecr_repo_name": "collector-api",
     "privacy_sandbox_aggregation_service_api": "<REPLACE WITH API GATEWAY URI FOR YOUR AGGREGATION SERVICE"
 }

--- a/deployment/collector_build.py
+++ b/deployment/collector_build.py
@@ -1,13 +1,13 @@
 import aws_cdk as cdk
 
-from aws_cdk import Stack, aws_iam as iam, aws_s3 as s3, aws_ecr as ecr, aws_codecommit as codecommit, aws_ssm as ssm
+from aws_cdk import Stack, NestedStack,aws_iam as iam, aws_s3 as s3, aws_ecr as ecr, aws_codecommit as codecommit, aws_ssm as ssm
 
 from aws_cdk import aws_codebuild as codebuild
 
 from constructs import Construct
 
 
-class CollectorBuild(Stack):
+class CollectorBuild(NestedStack):
 
     def __init__(
         self,

--- a/deployment/collector_build.py
+++ b/deployment/collector_build.py
@@ -1,11 +1,13 @@
 import aws_cdk as cdk
 
-from aws_cdk import Stack, NestedStack,aws_iam as iam, aws_s3 as s3, aws_ecr as ecr, aws_codecommit as codecommit, aws_ssm as ssm
+from aws_cdk import Stack,NestedStack,aws_iam as iam, aws_s3 as s3, aws_ecr as ecr, aws_codecommit as codecommit, aws_ssm as ssm
 
-from aws_cdk import aws_codebuild as codebuild
+
+from aws_cdk import aws_codebuild as codebuild, custom_resources as cr
 
 from constructs import Construct
 
+from cdk_nag import NagSuppressions
 
 class CollectorBuild(NestedStack):
 
@@ -30,6 +32,7 @@ class CollectorBuild(NestedStack):
           self,
           "collector_ecr_repo_name",
           removal_policy=cdk.RemovalPolicy.DESTROY,
+          empty_on_delete=True,
           image_scan_on_push=True,
           repository_name=self.collector_ecr_repo_name
         )
@@ -63,4 +66,46 @@ class CollectorBuild(NestedStack):
         )
         collector_container_uri.grant_write(build_project)
         self.container_repository.grant_pull_push(build_project)
-        
+
+      # start the collector build with a custom resource
+        trigger_build = cr.AwsSdkCall(service="CodeBuild",
+                            action="startBuild",
+                            parameters={
+                                "projectName": build_project.project_name
+                            },
+                            physical_resource_id=cr.PhysicalResourceId.from_response('build.arn'))
+
+        cr.AwsCustomResource(self, "trigger-collector-codebuild",
+                             policy=cr.AwsCustomResourcePolicy.from_sdk_calls(
+                                 resources=cr.AwsCustomResourcePolicy.ANY_RESOURCE),
+                             on_create=trigger_build,
+                             on_update=trigger_build)
+
+        # Export the build_project name and ARN
+        cdk.CfnOutput(
+            self, "BuildProjectName",
+            value=build_project.project_name,
+            description="Name of the CodeBuild project"
+        )
+
+        cdk.CfnOutput(
+            self, "BuildProjectArn",
+            value=build_project.project_arn,
+            description="ARN of the CodeBuild project"
+        )
+
+
+        # Suppress cdk-nag warnings for specific checks
+        NagSuppressions.add_stack_suppressions(
+            self,
+            [
+                {
+                    "id": "AwsSolutions-IAM4",
+                    "reason": "Default behaviour of CustomResource construct",
+                },
+                {
+                    'id': 'AwsSolutions-L1',
+                    'reason': 'Default behaviour of CustomResource construct',
+                },
+            ],
+        )

--- a/deployment/collector_service.py
+++ b/deployment/collector_service.py
@@ -1,5 +1,6 @@
 from aws_cdk import (
     Stack,
+    NestedStack,
     aws_ec2 as ec2,
     aws_ecs as ecs,
     aws_iam as iam,
@@ -15,7 +16,7 @@ from aws_cdk import (
 
 from constructs import Construct
 
-class CollectorServiceStack(Stack):
+class CollectorServiceStack(NestedStack):
 
     def __init__(
         self,

--- a/deployment/glue.py
+++ b/deployment/glue.py
@@ -3,6 +3,7 @@ from constructs import Construct
 from aws_cdk import (
     App, 
     Stack,
+    NestedStack,
     CfnOutput,
     Tags,
     aws_iam as iam,
@@ -20,7 +21,7 @@ from aws_cdk.aws_stepfunctions import (
     JsonPath
 )
 
-class GlueStack(Stack):
+class GlueStack(NestedStack):
 
     def __init__(self, scope: Construct, construct_id: str, kms_key,api_name: str,source_kinesis_stream,
                  s3_collector_destination, **kwargs) -> None:

--- a/deployment/kds.py
+++ b/deployment/kds.py
@@ -3,7 +3,7 @@ import string
 import aws_cdk as cdk
 from aws_cdk import (
   Stack,NestedStack,
-  aws_kinesis
+  aws_kinesis,RemovalPolicy
 )
 from constructs import Construct
 
@@ -24,10 +24,12 @@ class KinesisDataStreamsStack(NestedStack):
 
     self.kinesis_stream = aws_kinesis.Stream(self, "SourceKinesisStreams",
       retention_period=cdk.Duration.hours(int(self.kds_retention_hours)),
+      removal_policy = RemovalPolicy.DESTROY,
       encryption = aws_kinesis.StreamEncryption.KMS,
       encryption_key=kms_key,
       stream_mode=aws_kinesis.StreamMode.ON_DEMAND,
       stream_name=KINESIS_STREAM_NAME.value_as_string)
+
     
     cdk.CfnOutput(self, 'KinesisDataStreamsName',
       value=self.kinesis_stream.stream_name,

--- a/deployment/kds.py
+++ b/deployment/kds.py
@@ -2,13 +2,13 @@ import random
 import string
 import aws_cdk as cdk
 from aws_cdk import (
-  Stack,
+  Stack,NestedStack,
   aws_kinesis
 )
 from constructs import Construct
 
 
-class KinesisDataStreamsStack(Stack):
+class KinesisDataStreamsStack(NestedStack):
 
   def __init__(self, scope: Construct, construct_id: str,kms_key,api_name: str, **kwargs) -> None:
     super().__init__(scope, construct_id, **kwargs)

--- a/deployment/kms.py
+++ b/deployment/kms.py
@@ -1,10 +1,10 @@
 from aws_cdk import (
-  Stack,
+  Stack,NestedStack,
   aws_kms as kms,
 )
 from constructs import Construct
 
-class KMSKeyStack(Stack):
+class KMSKeyStack(NestedStack):
 
   def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
     super().__init__(scope, construct_id, **kwargs)

--- a/deployment/s3.py
+++ b/deployment/s3.py
@@ -1,11 +1,11 @@
 import aws_cdk as cdk
 from aws_cdk import (
-  Stack,
+  Stack,NestedStack,
   aws_s3 as s3,  
 )
 from constructs import Construct
 
-class S3Stack(Stack):
+class S3Stack(NestedStack):
 
   def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
     super().__init__(scope, construct_id, **kwargs)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added Nested stack for all the stacks
Made CodeBuild auto start the build
CDK was failing on second run of CDK because Kinesis was failing on because cdk was missing the delete policy on the stream.
ECR repo cleans up images
Made Glue jobs auto start and have a cdk.context.json flag called auto_start_glue_jobs with default to true.  In case dont want them running at start.
Removed the Readme manual steps for running the Codebuild and Glue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
